### PR TITLE
Preserve Source Editor Font between Runs

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -151,7 +151,8 @@ MainWindow::MainWindow(QWidget *parent)
     connect(terminalPane, SIGNAL(inputReceived()), this, SLOT(inputReceived()));
 
     // connect(ui->horizontalSplitter, SIGNAL(splitterMoved(int,int)), this, SLOT(resizeDocWidth(int,int)));
-
+    //Connect font defaulting signals
+    connect(this,SIGNAL(defaultFonts()),sourceCodePane,SLOT(onDefaultFonts()));
     readSettings();
 
     // Recent files
@@ -212,12 +213,13 @@ bool MainWindow::saveObject()
 
 void MainWindow::readSettings()
 {
-    QSettings settings("Pep9", "MainWindow");
+    QSettings settings("cslab.pepperdine", "Pep9");
     QDesktopWidget *desktop = QApplication::desktop();
     int width = static_cast<int>(desktop->width() * 0.80);
     int height = static_cast<int>(desktop->height() * 0.70);
     int screenWidth = desktop->width();
     int screenHeight = desktop->height();
+    settings.beginGroup("MainWindow");
     QPoint pos = settings.value("pos", QPoint((screenWidth - width) / 2, (screenHeight - height) / 2)).toPoint();
     QSize size = settings.value("size", QSize(width, height)).toSize();
     if (Pep::getSystem() == "Mac") {
@@ -232,14 +234,19 @@ void MainWindow::readSettings()
     resize(size);
     move(pos);
     curPath = settings.value("filePath", QDir::homePath()).toString();
+    settings.endGroup();
+    sourceCodePane->readSettings(settings);
 }
 
 void MainWindow::writeSettings()
 {
-    QSettings settings("Pep9", "MainWindow");
+    QSettings settings("cslab.pepperdine", "Pep9");
+    settings.beginGroup("MainWindow");
     settings.setValue("pos", pos());
     settings.setValue("size", size());
     settings.setValue("filePath", curPath);
+    settings.endGroup();
+    sourceCodePane->writeSettings(settings);
 }
 
 bool MainWindow::maybeSaveSource()
@@ -876,6 +883,11 @@ void MainWindow::on_actionEdit_Font_triggered()
         memoryDumpPane->updateGeometry();
         memoryDumpPane->setMaximumWidth(memoryDumpPane->memoryDumpWidth());
     }
+}
+
+void MainWindow::on_actionRest_Fonts_to_Default_triggered()
+{
+    emit defaultFonts();
 }
 
 void MainWindow::on_actionEdit_Remove_Error_Messages_triggered()

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -150,6 +150,7 @@ private slots:
     void on_actionEdit_Paste_triggered();
     void on_actionEdit_Format_From_Listing_triggered();
     void on_actionEdit_Font_triggered();
+    void on_actionRest_Fonts_to_Default_triggered();
     void on_actionEdit_Remove_Error_Messages_triggered();
 
     // Build
@@ -238,7 +239,9 @@ private slots:
     void slotSaveTraceTraps(int);
     void slotSaveTraceLoader(int);
 */
-
+signals:
+    //If a subobject needs to be aware of font resets, connect to this signal
+    void defaultFonts();
 };
 
 #endif // MAINWINDOW_H

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -370,6 +370,7 @@
     <addaction name="actionEdit_Remove_Error_Messages"/>
     <addaction name="separator"/>
     <addaction name="actionEdit_Font"/>
+    <addaction name="actionRest_Fonts_to_Default"/>
    </widget>
    <widget class="QMenu" name="menu_File">
     <property name="toolTip">
@@ -943,6 +944,11 @@
   <action name="actionSystem_Clear_Memory">
    <property name="text">
     <string>Clear Memory</string>
+   </property>
+  </action>
+  <action name="actionRest_Fonts_to_Default">
+   <property name="text">
+    <string>Reset Fonts to Default</string>
    </property>
   </action>
  </widget>

--- a/sourcecodepane.cpp
+++ b/sourcecodepane.cpp
@@ -402,6 +402,31 @@ void SourceCodePane::tab()
     }
 }
 
+void SourceCodePane::writeSettings(QSettings &settings)
+{
+    settings.beginGroup("SourceCodePane");
+    settings.setValue("EditorFont",ui->textEdit->font());
+    settings.endGroup();
+}
+
+void SourceCodePane::readSettings(QSettings &settings)
+{
+    settings.beginGroup("SourceCodePane");
+    QFont font = QFont(Pep::codeFont,Pep::codeFontSize);
+    QVariant val = settings.value("EditorFont",font);
+    if(val.canConvert<QFont>())
+    {
+        font = qvariant_cast<QFont>(val);
+    }
+    ui->textEdit->setFont(font);
+    settings.endGroup();
+}
+
+void SourceCodePane::onDefaultFonts()
+{
+    ui->textEdit->setFont(QFont(Pep::codeFont,Pep::codeFontSize));
+}
+
 void SourceCodePane::mouseReleaseEvent(QMouseEvent *)
 {
     ui->textEdit->setFocus();

--- a/sourcecodepane.h
+++ b/sourcecodepane.h
@@ -25,6 +25,7 @@
 #include <QWidget>
 #include <QString>
 #include <QList>
+#include <QSettings>
 #include "asm.h" // For Code in QList<Code *> codeList;
 #include "pephighlighter.h" // For syntax highlighting
 #include "enu.h"
@@ -140,6 +141,10 @@ public:
 
     void tab();
 
+    void writeSettings(QSettings& settings);
+    void readSettings(QSettings& settings);
+public slots:
+    void onDefaultFonts();
 private:
     Ui::SourceCodePane *ui;
     QList<Code *> codeList;


### PR DESCRIPTION
Re-organized settings file.
Font is now preserved for the source code editor between runs.
Added ability to rest all font to default.